### PR TITLE
Typescript 2.9 keyof changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sinon": "^4.4.6",
     "sinon-chai": "^3.0.0",
     "synchronous-promise": "^2.0.4",
-    "typescript": "^2.8.1",
+    "typescript": "^2.9.1",
     "wattle": "^0.3.1"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@
  *  - T & never = never
  *  - An object with a string index signature can be indexed with any string.
  */
-export declare type StringDiff<T extends string, U extends string> = ({
+export declare type KeyDiff<T extends string | number | symbol, U extends string | number | symbol> = ({
     [K in T]: K;
 } & {
     [K in U]: never;
@@ -16,14 +16,12 @@ export declare type StringDiff<T extends string, U extends string> = ({
  * From https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
  * Omits keys in K from object type T
  */
-export declare type ObjectOmit<T extends object, K extends StringKeyOf<T>> = Pick<T, StringDiff<StringKeyOf<T>, K>>;
+export declare type ObjectOmit<T extends object, K extends keyof T> = Pick<T, KeyDiff<keyof T, K>>;
 /**
  * Returns a version of type T where all properties which are also in U are optionalized.
- * Useful for makding props with defaults optional in React components.
+ * Useful for making props with defaults optional in React components.
  * Compare to flow's $Diff<> type: https://flow.org/en/docs/types/utilities/#toc-diff
  */
-export declare type ObjectDiff<T extends object, U extends object> = ObjectOmit<T, StringKeyOf<U> & StringKeyOf<T>> & {
+export declare type ObjectDiff<T extends object, U extends object> = ObjectOmit<T, keyof U & keyof T> & {
     [K in (keyof U & keyof T)]?: T[K];
 };
-
-export type StringKeyOf<T> = Extract<keyof T, string>; 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,12 +16,14 @@ export declare type StringDiff<T extends string, U extends string> = ({
  * From https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
  * Omits keys in K from object type T
  */
-export declare type ObjectOmit<T extends object, K extends keyof T> = Pick<T, StringDiff<keyof T, K>>;
+export declare type ObjectOmit<T extends object, K extends StringKeyOf<T>> = Pick<T, StringDiff<StringKeyOf<T>, K>>;
 /**
  * Returns a version of type T where all properties which are also in U are optionalized.
  * Useful for makding props with defaults optional in React components.
  * Compare to flow's $Diff<> type: https://flow.org/en/docs/types/utilities/#toc-diff
  */
-export declare type ObjectDiff<T extends object, U extends object> = ObjectOmit<T, keyof U & keyof T> & {
+export declare type ObjectDiff<T extends object, U extends object> = ObjectOmit<T, StringKeyOf<U> & StringKeyOf<T>> & {
     [K in (keyof U & keyof T)]?: T[K];
 };
+
+export type StringKeyOf<T> = Extract<keyof T, string>; 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,9 +1223,9 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
-typescript@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
+typescript@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
`StringDiff` is now `KeyDiff`