### PR TITLE
Upgrade typescript and fix recursive scoped event typing

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,9 +1,8 @@
 import { IObservable, ISimpleObservable, Observable } from './observable';
 import { Subject } from "./subject";
-import { ObjectDiff } from "./types";
 
 type Scopable<TIn, TOut> = TIn extends object ? TOut extends TIn
-    ? { scope<TScope extends Partial<TIn>>(scope: TScope): IObservableEvent<ObjectDiff<TIn, TScope>, TOut> }
+    ? { scope<TScope extends Subset<TIn, TScope>>(scope: TScope): IObservableEvent<Omit<TIn, keyof TScope>, TOut> }
     : {} : {};
 
 export type Event<T> = T extends void
@@ -38,11 +37,11 @@ class ObservableEvent<TIn extends object, TOut> extends Observable<TOut> {
         super(observer => source.subscribe(v => observer.next(v)));
     }
 
-    scope<TScope extends Subset<TOut, TScope>>(this: IObservableEvent<TIn, TOut>, scope: TScope): IObservableEvent<ObjectDiff<TIn, TScope>, TOut> {
-        let scopedEvent = (value: ObjectDiff<TIn, TScope>) => this(Object.assign(value, scope));
+    scope<TScope extends Subset<TIn, TScope>>(this: IObservableEvent<TIn, TOut>, scope: TScope): IObservableEvent<Omit<TIn, keyof TScope>, TOut> {
+        let scopedEvent = (value: Omit<TIn, keyof TScope>) => this(Object.assign(value, scope));
         let scopedObservable = this.filter(value => Object.keys(scope)
-            .every(p => value[p as keyof TOut] == scope[p as keyof TOut]));
-        return combineEventAndObservable(scopedEvent as Event<ObjectDiff<TIn, TScope>>, scopedObservable);
+            .every(p => value[p as keyof TOut] as any == scope[p as keyof TIn]));
+        return combineEventAndObservable(scopedEvent as Event<Omit<TIn, keyof TScope>>, scopedObservable);
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,1 @@
-/**
- * From https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-377567046
- * Omits keys in K from object type T
- */
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-/**
- * From https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-319495340
- * Returns a version of type T where all properties which are also in U are optionalized.
- * Useful for making props with defaults optional in React components.
- * Compare to flow's $Diff<> type: https://flow.org/en/docs/types/utilities/#toc-diff
- */
-export declare type ObjectDiff<T extends object, U extends object> = Omit<T, keyof U & keyof T> & {
-    [K in (keyof U & keyof T)]?: T[K];
-};
-
 export declare type StringKey<T> = string & keyof T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,9 +1428,9 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 typescript@~3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Upgrade to Typescript 3.7.2. There is now a depth limit to recursive typing, so had to tidy up scoped event typing.