### PR TITLE
ensure displayName is forwarded correctly by forwardRef and memo

### DIFF
--- a/packages/event-reduce-react/src/rendering.ts
+++ b/packages/event-reduce-react/src/rendering.ts
@@ -29,11 +29,11 @@ export function reactive<Component extends (ContextlessFunctionComponent<any> | 
         let observableProps = useAsObservableValues(props, `${componentName}.props`);
         return useReactive(componentName, () => component(observableProps, ...otherArgs as [any]));
     }) as ReactiveComponent<Component>;
-
+    reactiveComponent.displayName = componentName;
+    
     if (component.length == 2)
         reactiveComponent = forwardRef(reactiveComponent) as ReactiveComponent<Component>;
     reactiveComponent = memo<Component>(reactiveComponent as FunctionComponent<any>) as ReactiveComponent<Component>;
-    reactiveComponent.displayName = componentName;
     return reactiveComponent;
 }
 

--- a/packages/event-reduce-react/src/rendering.ts
+++ b/packages/event-reduce-react/src/rendering.ts
@@ -34,6 +34,7 @@ export function reactive<Component extends (ContextlessFunctionComponent<any> | 
     if (component.length == 2)
         reactiveComponent = forwardRef(reactiveComponent) as ReactiveComponent<Component>;
     reactiveComponent = memo<Component>(reactiveComponent as FunctionComponent<any>) as ReactiveComponent<Component>;
+    reactiveComponent.displayName = componentName;
     return reactiveComponent;
 }
 


### PR DESCRIPTION
Turns out that memo and forwardRef recursively search their inner components for the appropriate displayName.

Setting `displayName` on `reactiveComponent` before wrapping in memo and forwardRef fixes the issue where the component was always called `reactiveComponent`

